### PR TITLE
Added support for Joins among Siddhi streams

### DIFF
--- a/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
@@ -97,7 +97,17 @@ public class SiddhiExecutionPlanner {
                 retrievePartition(findStreamPartition((SingleInputStream) inputStream, selector));
             } else {
                 if (inputStream instanceof JoinInputStream) {
-                    throw new Exception("Join is not supported now!");
+                    SingleInputStream leftSingleInputStream = (SingleInputStream) ((JoinInputStream) inputStream)
+                            .getLeftInputStream();
+                    
+                    retrieveAliasForQuery(leftSingleInputStream, queryLevelAliasToStreamMapping);
+                    retrievePartition(findStreamPartition(leftSingleInputStream, selector));
+                    
+                    SingleInputStream rightSingleInputStream = (SingleInputStream) ((JoinInputStream) inputStream)
+                            .getRightInputStream();
+                  
+                    retrieveAliasForQuery(rightSingleInputStream, queryLevelAliasToStreamMapping);
+                    retrievePartition(findStreamPartition(rightSingleInputStream, selector));
                 } else if (inputStream instanceof StateInputStream) {
                     // Group By Spec
                     List<Variable> groupBy = selector.getGroupByList();


### PR DESCRIPTION
When multiple streams are defined and a union operation is invoked on the streams for a Join query in siddhi throws an exception saying "Join is not supported now!". The following code snippet represents the use case. Its confusing as to whether the Join operation was no more supported or is yet to be supported. However, this code change would allow the Join operation.

DataStream<Signal> output = cep.union("aStream","bStream").cql(controlEvents).returns("outputStream", Signal.class);