### PR TITLE
Exposing SiddhiOperatorContext from ExecutionSiddhiStream

### DIFF
--- a/core/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
@@ -274,6 +274,14 @@ public abstract class SiddhiStream {
             siddhiContext.setExtensions(environment.getExtensions());
             siddhiContext.setExecutionConfig(environment.getExecutionEnvironment().getConfig());
         }
+        
+        /**
+         * Return the SiddhiContext
+         * @return The Siddhi Operator context
+         */
+        public SiddhiOperatorContext getSiddhiContext() {
+          return this.siddhiContext;
+        }
 
         /**
          * @param outStreamId The <code>streamId</code> to return as data stream.


### PR DESCRIPTION
Added getter methos to expose SiddhiOperatorContext to the ExecutionSiddhiStream to allow better control over Siddhi Operator level parallelism. As of now it is not possible to set/control Siddhi Operator level parallelism without access to the operator context.